### PR TITLE
Update geofabrik link.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ tabula-0.9.2-jar-with-dependencies.jar:
 
 geo/berlin-latest.shp/roads.shp:
 	mkdir -p geo
-	wget -O geo/berlin-latest.shp.zip "http://download.geofabrik.de/europe/germany/berlin-latest.shp.zip"
+	wget -O geo/berlin-latest.shp.zip "http://download.geofabrik.de/europe/germany/berlin-latest-free.shp.zip"
 	unzip -d geo/berlin-latest.shp geo/berlin-latest.shp.zip
 
 pdfs/radfahrer%.pdf:


### PR DESCRIPTION
Hi, die ursprüngliche Datei ist nicht mehr bei Geofabrik, sehe in der [Liste](http://download.geofabrik.de/europe/germany/) die Datei `berlin-latest-free.shp.zip` als einzige sinnvolle Alternative. Habe also geupdated.

Allerdings habe ich jetzt bei der Ausführung von

    make out/accidents_points_2016.geojson

am Ende folgenden Fehler

     ....
     extracting: geo/berlin-latest.shp/gis.osm_waterways_free_1.cpg
      inflating: geo/berlin-latest.shp/gis.osm_waterways_free_1.dbf
      inflating: geo/berlin-latest.shp/gis.osm_waterways_free_1.prj
      inflating: geo/berlin-latest.shp/gis.osm_waterways_free_1.shp
      inflating: geo/berlin-latest.shp/gis.osm_waterways_free_1.shx
    python collect_streets.py geo/berlin-latest.shp/roads.shp > geo/berlin_streets.geojson
    Traceback (most recent call last):
      File "collect_streets.py", line 135, in <module>
        main(sys.argv[1])
      File "collect_streets.py", line 117, in main
        with fiona.open(shapefile, 'r') as shp:
      File "/usr/local/lib/python2.7/site-packages/fiona/__init__.py", line 162, in open
        raise IOError("no such file or directory: %r" % path)
    IOError: no such file or directory: 'geo/berlin-latest.shp/roads.shp'
    make: *** [geo/berlin_streets.geojson] Error 1

Weiß nicht, ob das an der neuen Datei liegt oder an was anderem.